### PR TITLE
Fix for dir being ignored when supplied and files always saved to cwd.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function save(urlOrMediaId, dir) {
         const mimeType = post.mimeType;
         const file = `${dir}/${filename}`;
 
-        downloadAndSave(downloadUrl, filename).then(() => {
+        downloadAndSave(downloadUrl, file).then(() => {
           return resolve({
             file,
             mimeType,


### PR DESCRIPTION
When using in node, the dir parameter would be ignored and files always saved to cwd.
